### PR TITLE
Revert remote cache section

### DIFF
--- a/chart/files/default.yml
+++ b/chart/files/default.yml
@@ -192,6 +192,9 @@ id: "aidx"
 # Media Proxy
 #mediaProxy: https://example.com/proxy
 
+# Proxy remote files (default: true)
+proxyRemoteFiles: true
+
 # Sign to ActivityPub GET request (default: true)
 signToActivityPubGet: true
 

--- a/packages/frontend/src/pages/admin/settings.vue
+++ b/packages/frontend/src/pages/admin/settings.vue
@@ -51,6 +51,24 @@ SPDX-License-Identifier: AGPL-3.0-only
 					</MkTextarea>
 
 					<FormSection>
+						<template #label>{{ i18n.ts.files }}</template>
+
+						<div class="_gaps_m">
+							<MkSwitch v-model="cacheRemoteFiles">
+								<template #label>{{ i18n.ts.cacheRemoteFiles }}</template>
+								<template #caption>{{ i18n.ts.cacheRemoteFilesDescription }}{{ i18n.ts.youCanCleanRemoteFilesCache }}</template>
+							</MkSwitch>
+
+							<template v-if="cacheRemoteFiles">
+								<MkSwitch v-model="cacheRemoteSensitiveFiles">
+									<template #label>{{ i18n.ts.cacheRemoteSensitiveFiles }}</template>
+									<template #caption>{{ i18n.ts.cacheRemoteSensitiveFilesDescription }}</template>
+								</MkSwitch>
+							</template>
+						</div>
+					</FormSection>
+
+					<FormSection>
 						<template #label>ServiceWorker</template>
 
 						<div class="_gaps_m">


### PR DESCRIPTION
`host` 브랜치에 일부 제어판 설정들이 누락되어있다고 합니다.
일부를 찾아서 복구하는 작업을 하고 있습니다.