### PR TITLE
유저 사일런스/정지 내역을 보이지 않게 처리함

### DIFF
--- a/packages/frontend/src/pages/user/home.vue
+++ b/packages/frontend/src/pages/user/home.vue
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <template>
 <MkSpacer :contentMax="narrow ? 800 : 1100">
 	<div ref="rootEl" class="ftskorzw" :class="{ wide: !narrow }" style="container-type: inline-size;">
-		<div class="main _gaps">
+		<div class="main _gaps"> 
 			<div v-if="user.isSuspended" class="punished"><i class="ti ti-alert-triangle" style="margin-right: 8px;"></i> {{ i18n.ts.userSuspended }}</div>
 			<div v-if="user.isLimited" class="punished"><i class="ti ti-alert-triangle" style="margin-right: 8px;"></i> {{ i18n.ts.userLimited }}</div>
 			<div v-if="user.isSilenced" class="punished"><i class="ti ti-alert-triangle" style="margin-right: 8px;"></i> {{ i18n.ts.userSilenced }}</div>
@@ -386,6 +386,7 @@ onUnmounted(() => {
 	> .main {
 
 		> .punished {
+			display: none;
 			font-size: 0.8em;
 			padding: 16px;
 			background: var(--infoWarnBg);


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
더 이상 유저 페이지 상단에 사일런스/정지 내역이 보이지 않습니다.

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
인스턴스를 여러 개 쓰는 사람이 많으므로, 특정 인스턴스에서 자신의 계정이 사일런스 처리된 것을 열람하거나 여러 가지 당황스러운 상황을 예방하기 위해서. 조정 시에 공지사항이나 스태프 계정으로 자세한 사항을 공지해주는 등 대안을 마련하는 방향으로 움직여야 하겠습니다.

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
![image](https://github.com/nekoplanet/misskey-io/assets/70682382/91705106-6ce8-403c-b282-9adbd895b86f)
도커가 어렵습니다. 정지 처리도 보이지 않습니당.

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
